### PR TITLE
Fix card closing date selection

### DIFF
--- a/Financials.Services/Features/Fatura/ObterFatura.cs
+++ b/Financials.Services/Features/Fatura/ObterFatura.cs
@@ -43,7 +43,10 @@ namespace Financials.Services.Features.Fatura
                 .GetByExpression(c => c.CartaoCreditoId == request.CartaoId)
                 .OrderByDescending(c => c.DataAlteracao);
 
-                var dataFechamentoVigente = ObterDataFechamentoVigente(alteracoesFechamento, request.DataReferencia);
+                var dataFechamentoVigente = ObterDataFechamentoVigente(
+                    alteracoesFechamento,
+                    request.DataReferencia,
+                    cartao.DataFechamento);
                 var (dataInicio, dataFim) = ObterPeriodoFatura(dataFechamentoVigente, request.DataReferencia);
 
                 var transacoes = _transacaoRepositorio
@@ -70,9 +73,13 @@ namespace Financials.Services.Features.Fatura
             return response;
         }
 
-        private static DateTime ObterDataFechamentoVigente(IEnumerable<DataFechamentoCartaoCredito> alteracoes, DateTime dataReferencia)
+        private static DateTime ObterDataFechamentoVigente(
+            IEnumerable<DataFechamentoCartaoCredito> alteracoes,
+            DateTime dataReferencia,
+            DateTime dataFechamentoAtual)
         {
-            return alteracoes.FirstOrDefault(c => c.DataAlteracao <= dataReferencia)?.DataFechamentoAnterior ?? dataReferencia;
+            return alteracoes.FirstOrDefault(c => c.DataAlteracao <= dataReferencia)?.DataFechamentoAnterior
+                ?? dataFechamentoAtual;
         }
 
         private static (DateTime dataInicio, DateTime dataFim) ObterPeriodoFatura(DateTime dataFechamento, DateTime dataReferencia)


### PR DESCRIPTION
## Summary
- fix `ObterDataFechamentoVigente` to default to the current closing date
- pass `cartao.DataFechamento` when getting the vigente closing date

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402b55a0f08329803963c586654861